### PR TITLE
Improve example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Get Flutter version
         id: get-flutter-version
-        use: zgosalvez/github-actions-get-flutter-version-env@v1
+        uses: zgosalvez/github-actions-get-flutter-version-env@v1
       - name: Set up Flutter
         uses: subosito/flutter-action@v1
         with:

--- a/README.md
+++ b/README.md
@@ -7,9 +7,13 @@ This GitHub Action (written in composite run steps) allows you to leverage GitHu
 Create a workflow `.yml` file in your `.github/workflows` directory. An [example workflow](#common-workflow) is available below. For more information, reference the GitHub Help Documentation for [Creating a workflow file](https://help.github.com/en/articles/configuring-a-workflow#creating-a-workflow-file).
 
 ### Inputs
+For more information on this input, see the [Workflow syntax for GitHub Actions](https://docs.github.com/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepswith)
+
 * `pubspec-file-path`: The pubspec.yaml file path. Optional. Default: `pubspec.yaml`
 
 ### Outputs
+For more information on this output, see the [Workflow syntax for GitHub Actions](https://docs.github.com/actions/reference/workflow-syntax-for-github-actions#jobsjob_idoutputs) and the [Context and expression syntax for GitHub Actions](https://docs.github.com/actions/reference/context-and-expression-syntax-for-github-actions#steps-context)
+
 * `version`: The Flutter version
 
 ### Common workflow

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ jobs:
         uses: actions/checkout@v2
       - name: Get Flutter version
         id: get-flutter-version
-        use: zgosalvez/github-actions-get-flutter-version-env@v1
+        uses: zgosalvez/github-actions-get-flutter-version-env@v1
+        with:
+          pubspec-file-path: app/pubspec.yaml
       - name: Set up Flutter
         uses: subosito/flutter-action@v1
         with:

--- a/README.md
+++ b/README.md
@@ -34,9 +34,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Get Flutter version
         id: get-flutter-version
-        uses: zgosalvez/github-actions-get-flutter-version-env@v1
-        with:
-          pubspec-file-path: app/pubspec.yaml
+        use: zgosalvez/github-actions-get-flutter-version-env@v1
       - name: Set up Flutter
         uses: subosito/flutter-action@v1
         with:


### PR DESCRIPTION
In the example, `use` is used instead of `uses` and I suggest that 
the readme shows how to set the input `pubspec-file-path`. This 
was not clear to me and I had to do some research to figure it out.