### PR TITLE
Transition to Node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ outputs:
   version: 
     description: "The Flutter version"
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: 'minimize'


### PR DESCRIPTION
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/